### PR TITLE
eslint-plugin-promise削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-config-standard": "^16.0.3",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^5.2.0",
         "npm-pack-zip": "^1.3.0",
         "textlint": "^12.1.0",
         "textlint-rule-abbr-within-parentheses": "^1.0.2",
@@ -4665,6 +4664,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       },
@@ -16575,6 +16575,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.2.0",
     "npm-pack-zip": "^1.3.0",
     "textlint": "^12.1.0",
     "textlint-rule-abbr-within-parentheses": "^1.0.2",


### PR DESCRIPTION
`eslint-plugin-promise` は `eslint-config-standard` から依存されていますが、バージョン周りをうまく解決できなかったので削除します。