### PR TITLE
aws-actions/configure-aws-credentialsの挿入位置を先頭に移動

### DIFF
--- a/.github/workflows/cdk-deploy.yml
+++ b/.github/workflows/cdk-deploy.yml
@@ -10,6 +10,11 @@ jobs:
   cdk-deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.1
         with:
@@ -18,9 +23,4 @@ jobs:
       - run: |
           npm install -g npm@7.21.0
           npm install
-      - uses: aws-actions/configure-aws-credentials@v1.6.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-1
       - run: npx cdk deploy --require-approval never

--- a/.github/workflows/cdk-diff.yml
+++ b/.github/workflows/cdk-diff.yml
@@ -8,6 +8,11 @@ jobs:
   cdk-diff:
     runs-on: ubuntu-latest
     steps:
+      - uses: aws-actions/configure-aws-credentials@v1.6.1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-1
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v2.5.1
         with:
@@ -16,11 +21,6 @@ jobs:
       - run: |
           npm install -g npm@7.21.0
           npm install
-      - uses: aws-actions/configure-aws-credentials@v1.6.1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-1
       # 差分があったときは差分を出力する
       - name: Show diff
         id: diff


### PR DESCRIPTION
DependabotによるPRのCIは `aws-actions/configure-aws-credentials` で失敗するため、このステップを先頭に移動してすぐ失敗するようにします。